### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/mms-engine.spec
+++ b/rpm/mms-engine.spec
@@ -30,9 +30,9 @@ Requires: libdbuslogserver-gio >= %{libdbuslog_version}
 Requires(post): glib2
 Requires(postun): glib2
 
-BuildRequires: systemd
 BuildRequires: file-devel
 BuildRequires: libjpeg-turbo-devel
+BuildRequires: pkgconfig(systemd)
 BuildRequires: pkgconfig(dconf)
 BuildRequires: pkgconfig(libpng)
 BuildRequires: pkgconfig(libexif)


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.