### PR TITLE
[mms-engine] Migrate to GMime 3.0. JB#56421

### DIFF
--- a/mms-engine/Makefile
+++ b/mms-engine/Makefile
@@ -18,7 +18,7 @@ include ../mms-lib/Config.mak
 #
 
 PKGS = gio-unix-2.0 gio-2.0 libdbusaccess libglibutil libdbuslogserver-gio
-LIB_PKGS = libwspcodec gmime-2.6 libgofono libsoup-2.4 dconf
+LIB_PKGS = libwspcodec gmime-3.0 libgofono libsoup-2.4 dconf
 
 ifdef SAILFISH
 LIB_PKGS += libgofonoext

--- a/mms-engine/mms-engine.pro
+++ b/mms-engine/mms-engine.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 CONFIG += link_pkgconfig
-PKGCONFIG += gmime-2.6 gio-unix-2.0 gio-2.0 glib-2.0 libsoup-2.4 dconf
+PKGCONFIG += gmime-3.0 gio-unix-2.0 gio-2.0 glib-2.0 libsoup-2.4 dconf
 PKGCONFIG += libwspcodec libgofono libdbusaccess libglibutil libdbuslogserver-gio
 QMAKE_CFLAGS += -Wno-unused-parameter
 

--- a/mms-lib/Makefile
+++ b/mms-lib/Makefile
@@ -12,7 +12,7 @@ include Config.mak
 # Required packages
 #
 
-PKGS = libglibutil libwspcodec gmime-2.6 libsoup-2.4 glib-2.0
+PKGS = libglibutil libwspcodec gmime-3.0 libsoup-2.4 glib-2.0
 
 #
 # Default target

--- a/mms-lib/mms-lib.pro
+++ b/mms-lib/mms-lib.pro
@@ -1,7 +1,7 @@
 TEMPLATE = lib
 CONFIG += staticlib
 CONFIG += link_pkgconfig
-PKGCONFIG += libglibutil libwspcodec gmime-2.6 glib-2.0 libsoup-2.4
+PKGCONFIG += libglibutil libwspcodec gmime-3.0 glib-2.0 libsoup-2.4
 INCLUDEPATH += include
 QMAKE_CFLAGS += -Wno-unused-parameter
 

--- a/mms-lib/test/common/Makefile
+++ b/mms-lib/test/common/Makefile
@@ -23,7 +23,7 @@ include ../../Config.mak
 # Required packages
 #
 
-PKGS += gmime-2.6 glib-2.0 libsoup-2.4 libglibutil
+PKGS += gmime-3.0 glib-2.0 libsoup-2.4 libglibutil
 LIB_PKGS += $(PKGS) libwspcodec $(RESIZE_PKG)
 
 #

--- a/rpm/mms-engine.spec
+++ b/rpm/mms-engine.spec
@@ -36,7 +36,7 @@ BuildRequires: pkgconfig(systemd)
 BuildRequires: pkgconfig(dconf)
 BuildRequires: pkgconfig(libpng)
 BuildRequires: pkgconfig(libexif)
-BuildRequires: pkgconfig(gmime-2.6)
+BuildRequires: pkgconfig(gmime-3.0)
 BuildRequires: pkgconfig(glib-2.0) >= %{glib_version}
 BuildRequires: pkgconfig(libsoup-2.4) >= %{libsoup_version}
 BuildRequires: pkgconfig(libwspcodec) >= %{libwspcodec_version}


### PR DESCRIPTION
Such a small subset of the api used we can just bump the versions.
Depends on https://github.com/sailfishos/gmime/pull/1

@monich @Tomin1 @mlehtima 