### PR TITLE
[mms-engine] Only run unit tests on x86 and x86_64. JB#62303

### DIFF
--- a/rpm/mms-engine.spec
+++ b/rpm/mms-engine.spec
@@ -125,8 +125,10 @@ glib-compile-schemas %{glibschemas}
 %postun
 glib-compile-schemas %{glibschemas}
 
+%ifarch %{ix86} x86_64
 %check
 make -C mms-lib/test GMIME_PACKAGE="%{gmime_package}" test
+%endif
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
QEMU or sb2 is causing issues with new libjpeg-turbo which results in unit test failing when run within sb2. Tests run without issues on device.