### PR TITLE
Fix a couple details clang scan-build was complaining about

### DIFF
--- a/mms-lib/src/mms_codec.c
+++ b/mms-lib/src/mms_codec.c
@@ -2093,7 +2093,6 @@ static gboolean mms_encode_send_req_part_header(struct mms_attachment *part,
 	const char *ct_str;
 	char *name = NULL;
 	unsigned int ctp_len;
-	unsigned int cid_len;
 	unsigned int cloc_len;
 	unsigned int cd_len;
 	unsigned char ctp_val[MAX_ENC_VALUE_BYTES];
@@ -2152,10 +2151,8 @@ static gboolean mms_encode_send_req_part_header(struct mms_attachment *part,
 
 	/* Compute content-id header length : token + (Quoted String) */
 	if (part->content_id != NULL) {
-		cid_len = 1 + strlen(part->content_id) + 3 + 1;
-		len += cid_len;
-	} else
-		cid_len = 0;
+		len += 1 + strlen(part->content_id) + 3 + 1;
+	}
 
 	/* Compute content-location header length : text-string */
 	if (part->content_location != NULL) {


### PR DESCRIPTION
The unrefs caused use-after free warning.  Other seemed like a duplicate line and mms_task_encode_job_done() gets called only by mms_encode_job_done() which does another unref.

Besides these, there's a remaining warning for mms_attachment_image.c division by zero on denominator variable. I think that doesn't happen in practice as it can be zero only on upscaling which would be broken there anyway (nx or ny zero would mean it doesn't copy any pixels). But the code looks fishy even otherwise, doing pixel averaging by dividing first and loosing information from least significant bits. Even wondering should the whole resizing part even exist, graphical operations might be better delegated to libraries specialized in that.